### PR TITLE
Different Page Types

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,56 +172,7 @@ def index():
 
     threejs_template_data = create_threejs_data(animation, data_selected)
     
-    try:
-        # Get menu items and parse query parameters
-        menu = get_menu_items()
-        
-        # Get template from S3 and website data from DynamoDB
-        template = get_s3_template(s3_env, os.environ['BUCKET_NAME'], local=LOCAL)
-        website_data = get_website_data(os.environ['HOME_TABLE'])
-        
-        # Query articles
-        try:
-            if before:
-                direction = 'newer'
-                cursor = before
-            else:
-                direction = 'older'
-                cursor = after
-
-            items, next_key, prev_key = list_articles(
-                tag=tag,
-                start_key=cursor,
-                full_articles=False,
-                direction=direction
-            )
-
-            print(f"[DEBUG] Direction: {direction}, Tag: {tag}, After: {after}, Before: {before}, Cursor: {cursor}, Number of items: {len(items)}")
-        except Exception as e:
-            print("Error querying DynamoDB:", e)
-            return Response(str(e), status_code=500)
-
-        print('[DEBUG] Queried articles:', len(items), items)
-
-        print('prev_key', prev_key)
-        print('next_key', next_key)
-
-        # Render template
-        template_data = {
-            'social': website_data['social'],
-            'articles': items,
-            'menu': menu,
-            'prev_key': prev_key,
-            'next_key': next_key,
-        }
-        html_content = template.render(**template_data, **threejs_template_data)
-        
-        # Create and return response
-        return create_compressed_response(html_content, skip_caching=True)
-    
-    except Exception as e:
-        print(f"Unexpected error in script_template: {e}")
-        return Response(str(e), status_code=500)
+    return fetch_paginated(after, before, tag, threejs_template_data)
 
 
 @app.route('/index.html')

--- a/app.py
+++ b/app.py
@@ -181,6 +181,47 @@ def index_html():
     return Response(body='', headers={'Location': 'https://www.darrenmackenzie.com'}, status_code=301)
 
 
+@app.route('/projects')
+def projects():
+    """Handle the main website endpoint."""
+    if DEBUG:
+        debug(app.current_request)
+
+    query_params = app.current_request.query_params or {}
+
+    after = _unb64(query_params.get("after"))
+    before = _unb64(query_params.get("before"))
+
+    tag = query_params.get('tag') if query_params else None
+
+    animation = query_params.get('animation', 'multiaxis') if query_params else 'multiaxis'
+    data_selected = query_params.get('data_selected', 'data') if query_params else 'data'
+
+    threejs_template_data = create_threejs_data(animation, data_selected)
+
+    return fetch_paginated(after, before, tag, threejs_template_data, article_type='PROJECT', page_name='Projects')
+
+
+@app.route('/work')
+def work():
+    """Handle the main website endpoint."""
+    if DEBUG:
+        debug(app.current_request)
+
+    query_params = app.current_request.query_params or {}
+
+    after = _unb64(query_params.get("after"))
+    before = _unb64(query_params.get("before"))
+
+    tag = query_params.get('tag') if query_params else None
+
+    animation = query_params.get('animation', 'multiaxis') if query_params else 'multiaxis'
+    data_selected = query_params.get('data_selected', 'data') if query_params else 'data'
+
+    threejs_template_data = create_threejs_data(animation, data_selected)
+
+    return fetch_paginated(after, before, tag, threejs_template_data, article_type='WORK', page_name='Past Work')
+
 def serve_threejs_helper(animation: str = 'multiaxis', query_params: dict = None, fullscreen: bool = False):
     print('ABOUT TO SERVE THREEJS ANIMATION:', animation)
     s3 = boto3.resource('s3')

--- a/app.py
+++ b/app.py
@@ -354,8 +354,12 @@ def contact_form():
     INDIVIDUAL PAGES
 """
 
+# TODO: Fetch these from a key-value store.
+
 ARTICLE_SLUGS_TO_SK = {
-    'lambda-layers': 1
+    'lambda-layers': 1,
+    'a-project': 1,
+    'some-work-i-did': 1
 }
 
 SECTIONS_DICT = {

--- a/app.py
+++ b/app.py
@@ -354,14 +354,6 @@ def contact_form():
     INDIVIDUAL PAGES
 """
 
-# TODO: Fetch these from a key-value store.
-
-ARTICLE_SLUGS_TO_SK = {
-    'lambda-layers': 1,
-    'a-project': 1,
-    'some-work-i-did': 1
-}
-
 SECTIONS_DICT = {
     'articles': 'ARTICLE',
     'blog': 'ARTICLE',
@@ -396,7 +388,10 @@ def articles(section, article):
     article_table = db.Table(os.environ['ARTICLES_V2_TABLE'])
 
     pk = SECTIONS_DICT.get(section, None)
-    sk = ARTICLE_SLUGS_TO_SK.get(article, None)
+    sk = article.split('-')[0] if '-' in article else None
+
+    try: sk = int(sk)
+    except ValueError: sk = None
 
     if not pk or not sk:
         html_content = s3_env.from_string(
@@ -409,6 +404,7 @@ def articles(section, article):
             status_code=404
         )
 
+    print("[DEBUG] Fetching article with PK:", pk, "and SK:", sk)
     article_data = article_table.get_item(Key={'PK': pk, 'SK': sk}).get('Item', None)
 
     if DEBUG:

--- a/app.py
+++ b/app.py
@@ -358,6 +358,13 @@ ARTICLE_SLUGS_TO_SK = {
     'lambda-layers': 1
 }
 
+SECTIONS_DICT = {
+    'articles': 'ARTICLE',
+    'blog': 'ARTICLE',
+    'projects': 'PROJECT',
+    'work': 'WORK',
+    'services': 'SERVICE',
+}
 
 @app.route('/{section}/{article}')
 def articles(section, article):

--- a/chalicelib/main.py
+++ b/chalicelib/main.py
@@ -13,8 +13,9 @@ def get_menu_items():
     """Return a list of menu items for the website."""
     return [
         dict(title='Home', url='/'),
-        dict(title='About', url='#about'),
+        #dict(title='About', url='#about'),
         dict(title='Blog', url='#blogarticles'),
+        dict(title='Projects', url='/projects'),
         # dict(title='Contact', url='#contact')
     ]
 

--- a/chalicelib/main.py
+++ b/chalicelib/main.py
@@ -14,8 +14,8 @@ def get_menu_items():
     return [
         dict(title='Home', url='/'),
         #dict(title='About', url='#about'),
-        dict(title='Blog', url='#blogarticles'),
-        dict(title='Projects', url='/projects'),
+        dict(title='Blog', url='https://www.darrenmackenzie.com/#blogarticles'),
+        dict(title='Projects', url='https://www.darrenmackenzie.com/projects'),
         # dict(title='Contact', url='#contact')
     ]
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,8 +10,8 @@
         media="print"
         onload="this.media='all'"
     ></link>
-    <title>dm creations - Home</title>
-    <meta name="description" content="Personal website of Darren MacKenzie, a software developer and solution architect."></meta>
+    <title>dm creations - {{ page_name }}</title>
+    <meta name="description" content="Personal website of Darren MacKenzie, a software developer and solution architect. The current page is {{ page_name }}."></meta>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
     <link rel="stylesheet" href="/style.css"></link>
 
@@ -45,7 +45,7 @@
 
         <main class="main-grid">
             <div class="service blogarticles" id="blogarticles">
-                <div class="title"><h2>Blog</h2></div>
+                <div class="title"><h2>{{ page_name }}</h2></div>
                 {% if not articles %}
                 <div class="centered-text">
                     <h3>You've reached the end.</h3>


### PR DESCRIPTION
The site now has the capacity for any arbitrary article subtype with its own URL path prefix.

Endpoints were added for `projects` and for `work`, although the `work` menu link is still left out for now.